### PR TITLE
Fix broken masked link in Permissions page

### DIFF
--- a/Cogs/Configuration/Components/Permissions.py
+++ b/Cogs/Configuration/Components/Permissions.py
@@ -100,7 +100,7 @@ async def PermissionsEmbed(
     )
     embed.set_author(name=f"{interaction.guild.name}", icon_url=interaction.guild.icon)
     embed.set_thumbnail(url=interaction.guild.icon)
-    embed.description = "> This is where you can manage your server's permissions! If you wanna know more about what these permissions do head to the [advanced permissions page](https://docs.astrobirb.dev/advanced-permissions) on the [documentation](https:/docs.astrobirb.dev)\n"
+    embed.description = "> This is where you can manage your server's permissions! If you wanna know more about what these permissions do head to the [advanced permissions page](https://docs.astrobirb.dev/advanced-permissions) on the [documentation](https://docs.astrobirb.dev)\n"
     value = f"{replytop} `Staff Role:` {StaffRole} \n{replybottom} `Admin Role:` {AdminRole}\n\nIf you need help either go to the [support server](https://discord.gg/36xwMFWKeC) or read the [documentation](https://docs.astrobirb.dev)"
     if len(value) > 1021:
         value = value[:1018] + "..."


### PR DESCRIPTION
It wasn't parsing properly because the link was written as "https:/"

<img width="500" height="111" alt="image" src="https://github.com/user-attachments/assets/52c65722-b0f9-4658-a8df-2d93edbd0907" />