### PR TITLE
Update documentation links in module embeds

### DIFF
--- a/Cogs/Configuration/Components/AutoResponse.py
+++ b/Cogs/Configuration/Components/AutoResponse.py
@@ -206,5 +206,5 @@ class DeleteByTrigger2(discord.ui.Modal):
 async def AutoResponseEmbed(interaction: discord.Interaction, embed: discord.Embed):
     embed.set_author(name=f"{interaction.guild.name}", icon_url=interaction.guild.icon)
     embed.set_thumbnail(url=interaction.guild.icon)
-    embed.description = "> Autoresponses are automatic messages sent when a message matches a trigger. You can set the similarity of the trigger, so it only responds when the message is similar enough.\n\nYou can find out more at [the documentation](https://docs.astrobirb.dev/)."
+    embed.description = "> Autoresponses are automatic messages sent when a message matches a trigger. You can set the similarity of the trigger, so it only responds when the message is similar enough.\n\nYou can find out more at [the documentation](https://docs.astrobirb.dev/Modules/responder)."
     return embed

--- a/Cogs/Configuration/Components/Infractions.py
+++ b/Cogs/Configuration/Components/Infractions.py
@@ -1382,7 +1382,7 @@ async def InfractionEmbed(
 
     embed.set_author(name=f"{interaction.guild.name}", icon_url=interaction.guild.icon)
     embed.set_thumbnail(url=interaction.guild.icon)
-    embed.description = "> This is where you can manage your server's infraction settings! Infractions are a way to punish staff members. You can find out more at [the documentation](https://docs.astrobirb.dev/)."
+    embed.description = "> This is where you can manage your server's infraction settings! Infractions are a way to punish staff members. You can find out more at [the documentation](https://docs.astrobirb.dev/Modules/infractions)."
     Types = Config.get("Infraction", {}).get(
         "types",
         [
@@ -1395,7 +1395,7 @@ async def InfractionEmbed(
         ],
     )
     Reasons = Config.get("Infraction", {}).get("reasons", [])
-    value = f"{replytop} `Infraction Channel:` {Channel}\n{replymiddle} `Audit Log Channel`:  {Audit}\n{replymiddle} `Types:` {', '.join(Types)}\n{replybottom} `Reasons:` {', '.join(Reasons) if Reasons else 'Not Configured'}\n\nIf you need help either go to the [support server](https://discord.gg/36xwMFWKeC) or read the [documentation](https://docs.astrobirb.dev)"[
+    value = f"{replytop} `Infraction Channel:` {Channel}\n{replymiddle} `Audit Log Channel`:  {Audit}\n{replymiddle} `Types:` {', '.join(Types)}\n{replybottom} `Reasons:` {', '.join(Reasons) if Reasons else 'Not Configured'}\n\nIf you need help either go to the [support server](https://discord.gg/36xwMFWKeC) or read the [documentation](https://docs.astrobirb.dev/Modules/infractions)"[
         :1024
     ]
 

--- a/Cogs/Configuration/Components/LOA.py
+++ b/Cogs/Configuration/Components/LOA.py
@@ -268,10 +268,10 @@ async def LOAEmbed(
 
     embed.set_author(name=f"{interaction.guild.name}", icon_url=interaction.guild.icon)
     embed.set_thumbnail(url=interaction.guild.icon)
-    embed.description = "> This is where you can manage your server's LOA settings! LOA is a way for staff members to take a break from their duties. You can find out more at [the documentation](https://docs.astrobirb.dev/)."
+    embed.description = "> This is where you can manage your server's LOA settings! LOA is a way for staff members to take a break from their duties. You can find out more at [the documentation](https://docs.astrobirb.dev/Modules/loa)."
     embed.add_field(
         name="<:settings:1207368347931516928> LOA",
-        value=f"{replytop} `LOA Channel:` {Channel}\n{replymiddle} `LOA Audit Channel`: {LogChannel}\n{replybottom} `LOA Role:` {Role}\n\nIf you need help either go to the [support server](https://discord.gg/36xwMFWKeC) or read the [documentation](https://docs.astrobirb.dev)",
+        value=f"{replytop} `LOA Channel:` {Channel}\n{replymiddle} `LOA Audit Channel`: {LogChannel}\n{replybottom} `LOA Role:` {Role}\n\nIf you need help either go to the [support server](https://discord.gg/36xwMFWKeC) or read the [documentation](https://docs.astrobirb.dev/Modules/loa)",
         inline=False,
     )
     return embed

--- a/Cogs/Configuration/Components/MessageQuota.py
+++ b/Cogs/Configuration/Components/MessageQuota.py
@@ -587,10 +587,10 @@ async def MessageQuotaEmbed(
         )
         or "Not Configured"
     )
-    embed.description = "> This is where you can manage your server's message quota! If you wanna know more about what this does head to the [message quota page](https://docs.astrobirb.dev/Modules/quota) on the [documentation](https:/docs.astrobirb.dev)\n"
+    embed.description = "> This is where you can manage your server's message quota! You can find out more at [the documentation](https://docs.astrobirb.dev/Modules/quota).\n"
     embed.add_field(
         name="<:settings:1207368347931516928> Message Quota",
-        value=f"{replytop} `Quota:` {Config.get('Message Quota', {}).get('quota', 'Not Configured')}\n{replybottom} `Ignored Channels:` {IgnoredChannels}\n\nIf you need help either go to the [support server](https://discord.gg/36xwMFWKeC) or read the [documentation](https://docs.astrobirb.dev)",
+        value=f"{replytop} `Quota:` {Config.get('Message Quota', {}).get('quota', 'Not Configured')}\n{replybottom} `Ignored Channels:` {IgnoredChannels}\n\nIf you need help either go to the [support server](https://discord.gg/36xwMFWKeC) or read the [documentation](https://docs.astrobirb.dev/Modules/quota)",
         inline=False,
     )
     return embed

--- a/Cogs/Configuration/Components/Modmail.py
+++ b/Cogs/Configuration/Components/Modmail.py
@@ -975,12 +975,12 @@ async def ModmailEmbed(
 
     embed.set_author(name=f"{interaction.guild.name}", icon_url=interaction.guild.icon)
     embed.set_thumbnail(url=interaction.guild.icon)
-    embed.description = "> This is where you can manage your server's modmail settings! Modmail is a way for users to contact staff. You can find out more at [the documentation](https://docs.astrobirb.dev/)."
+    embed.description = "> This is where you can manage your server's modmail settings! Modmail is a way for users to contact staff. You can find out more at [the documentation](https://docs.astrobirb.dev/Modules/modmail)."
     if config.get("Module Options", {}).get("ModmailType", "channel") == "channel":
-        value = f"{replytop} `Category:` {Category}\n{replymiddle} `Transcripts:` {Transcripts}\n{replybottom} `Roles:` {ModmailRoles}\n\nIf you need help either go to the [support server](https://discord.gg/36xwMFWKeC) or read the [documentation](https://docs.astrobirb.dev)"
+        value = f"{replytop} `Category:` {Category}\n{replymiddle} `Transcripts:` {Transcripts}\n{replybottom} `Roles:` {ModmailRoles}\n\nIf you need help either go to the [support server](https://discord.gg/36xwMFWKeC) or read the [documentation](https://docs.astrobirb.dev/Modules/modmail)."
 
     else:
-        value = f"{replytop} `Threads Channel:` <#{config.get('Modmail', {}).get('threads', 'Not Configured')}>\n{replybottom} `Roles:` {ModmailRoles}\n\nIf you need help either go to the [support server](https://discord.gg/36xwMFWKeC) or read the [documentation](https://docs.astrobirb.dev)"
+        value = f"{replytop} `Threads Channel:` <#{config.get('Modmail', {}).get('threads', 'Not Configured')}>\n{replybottom} `Roles:` {ModmailRoles}\n\nIf you need help either go to the [support server](https://discord.gg/36xwMFWKeC) or read the [documentation](https://docs.astrobirb.dev/Modules/modmail)."
 
     embed.add_field(
         name="<:settings:1207368347931516928> Modmail",

--- a/Cogs/Configuration/Components/Permissions.py
+++ b/Cogs/Configuration/Components/Permissions.py
@@ -100,8 +100,8 @@ async def PermissionsEmbed(
     )
     embed.set_author(name=f"{interaction.guild.name}", icon_url=interaction.guild.icon)
     embed.set_thumbnail(url=interaction.guild.icon)
-    embed.description = "> This is where you can manage your server's permissions! If you wanna know more about what these permissions do head to the [advanced permissions page](https://docs.astrobirb.dev/advanced-permissions) on the [documentation](https://docs.astrobirb.dev)\n"
-    value = f"{replytop} `Staff Role:` {StaffRole} \n{replybottom} `Admin Role:` {AdminRole}\n\nIf you need help either go to the [support server](https://discord.gg/36xwMFWKeC) or read the [documentation](https://docs.astrobirb.dev)"
+    embed.description = "> This is where you can manage your server's permissions! If you wanna know more about what these permissions do head to the [advanced permissions page](https://docs.astrobirb.dev/advanced-permissions) on the [documentation](https://docs.astrobirb.dev/configuration/permissions)\n"
+    value = f"{replytop} `Staff Role:` {StaffRole} \n{replybottom} `Admin Role:` {AdminRole}\n\nIf you need help either go to the [support server](https://discord.gg/36xwMFWKeC) or read the [documentation](https://docs.astrobirb.dev/configuration/permissions)."
     if len(value) > 1021:
         value = value[:1018] + "..."
 

--- a/Cogs/Configuration/Components/Promotions.py
+++ b/Cogs/Configuration/Components/Promotions.py
@@ -1181,10 +1181,10 @@ async def PromotionEmbed(
 
     embed.set_author(name=f"{interaction.guild.name}", icon_url=interaction.guild.icon)
     embed.set_thumbnail(url=interaction.guild.icon)
-    embed.description = "> This is where you can manage your server's promotion settings! Promotions are a way to give staff members more power. You can find out more at [the documentation](https://docs.astrobirb.dev/)."
+    embed.description = "> This is where you can manage your server's promotion settings! Promotions are a way to give staff members more power. You can find out more at [the documentation](https://docs.astrobirb.dev/Modules/promotions)."
     embed.add_field(
         name="<:settings:1207368347931516928> Promotions",
-        value=f"> {replytop} `System:` {System}\n> {replymiddle} `Promotion Channel:` {Channel}\n> {replybottom} `Cooldown:` {Days}\n\nIf you need help either go to the [support server](https://discord.gg/36xwMFWKeC) or read the [documentation](https://docs.astrobirb.dev)",
+        value=f"> {replytop} `System:` {System}\n> {replymiddle} `Promotion Channel:` {Channel}\n> {replybottom} `Cooldown:` {Days}\n\nIf you need help either go to the [support server](https://discord.gg/36xwMFWKeC) or read the [documentation](https://docs.astrobirb.dev/Modules/promotions).",
         inline=False,
     )
     return embed

--- a/Cogs/Configuration/Components/QOTD.py
+++ b/Cogs/Configuration/Components/QOTD.py
@@ -490,10 +490,10 @@ async def QOTDEMbed(interaction: discord.Interaction, embed: discord.Embed):
 
     embed.set_author(name=f"{interaction.guild.name}", icon_url=interaction.guild.icon)
     embed.set_thumbnail(url=interaction.guild.icon)
-    embed.description = "> This is where you can manage your server's QOTD settings! QOTD is a way for members to answer a question of the day. You can find out more at [the documentation](https://docs.astrobirb.dev/)."
+    embed.description = "> This is where you can manage your server's QOTD settings! QOTD is a way for members to answer a question of the day. You can find out more at [the documentation](https://docs.astrobirb.dev/Modules/qotd)."
     embed.add_field(
         name="<:settings:1207368347931516928> Daily Questions",
-        value=f"{replytop} `Channel:` {channel}\n{replymiddle} `Ping`: {ping}\n{replybottom} `Next Date:` {NextDate} (Not 100% accurate)\n\nIf you need help either go to the [support server](https://discord.gg/36xwMFWKeC) or read the [documentation](https://docs.astrobirb.dev)",
+        value=f"{replytop} `Channel:` {channel}\n{replymiddle} `Ping`: {ping}\n{replybottom} `Next Date:` {NextDate} (Not 100% accurate)\n\nIf you need help either go to the [support server](https://discord.gg/36xwMFWKeC) or read the [documentation](https://docs.astrobirb.dev/Modules/qotd).",
         inline=False,
     )
     return embed

--- a/Cogs/Configuration/Components/StaffFeedback.py
+++ b/Cogs/Configuration/Components/StaffFeedback.py
@@ -322,10 +322,10 @@ async def StaffFeedbackEmbed(
 
     embed.set_author(name=f"{interaction.guild.name}", icon_url=interaction.guild.icon)
     embed.set_thumbnail(url=interaction.guild.icon)
-    embed.description = "> This is where you can manage your server's staff feedback settings! Staff feedback is a way for members to give feedback to staff. You can find out more at [the documentation](https://docs.astrobirb.dev/)."
+    embed.description = "> This is where you can manage your server's staff feedback settings! Staff feedback is a way for members to give feedback to staff. You can find out more at [the documentation](https://docs.astrobirb.dev/Modules/feedback)."
     embed.add_field(
         name="<:settings:1207368347931516928> Staff Feedback",
-        value=f"> `Feedback Channel:` {Channel}\n\nIf you need help either go to the [support server](https://discord.gg/36xwMFWKeC) or read the [documentation](https://docs.astrobirb.dev)",
+        value=f"> `Feedback Channel:` {Channel}\n\nIf you need help either go to the [support server](https://discord.gg/36xwMFWKeC) or read the [documentation](https://docs.astrobirb.dev/Modules/feedback).",
         inline=False,
     )
     return embed

--- a/Cogs/Configuration/Components/StaffPanel.py
+++ b/Cogs/Configuration/Components/StaffPanel.py
@@ -165,6 +165,6 @@ async def StaffPanelEmbed(interaction: discord.Interaction, embed: discord.Embed
     embed.description = (
         "> The Staff Panel provides an overview of all staff members, including their roles, "
         "joining dates, and introductions. Select a staff member to view detailed information. "
-        "Learn more in [the documentation](https://docs.astrobirb.dev/)."
+        "Learn more in [the documentation](https://docs.astrobirb.dev/Modules/Staffdb)."
     )
     return embed

--- a/Cogs/Configuration/Components/Suggestions.py
+++ b/Cogs/Configuration/Components/Suggestions.py
@@ -375,10 +375,10 @@ async def SuggestionsEmbed(
 
     embed.set_author(name=f"{interaction.guild.name}", icon_url=interaction.guild.icon)
     embed.set_thumbnail(url=interaction.guild.icon)
-    embed.description = "> This is where you can manage your server's suggestions settings! Suggestions is a way for members to give suggestions to the server. You can find out more at [the documentation](https://docs.astrobirb.dev/)."
+    embed.description = "> This is where you can manage your server's suggestions settings! Suggestions is a way for members to give suggestions to the server. You can find out more at [the documentation](https://docs.astrobirb.dev/Modules/suggestions)."
     embed.add_field(
         name="<:settings:1207368347931516928> Suggestions",
-        value=f"> `Suggestions Channel:` {Channel}\n\nIf you need help either go to the [support server](https://discord.gg/36xwMFWKeC) or read the [documentation](https://docs.astrobirb.dev)",
+        value=f"> `Suggestions Channel:` {Channel}\n\nIf you need help either go to the [support server](https://discord.gg/36xwMFWKeC) or read the [documentation](https://docs.astrobirb.dev/Modules/suggestions).",
         inline=False,
     )
     return embed

--- a/Cogs/Configuration/Components/Tickets.py
+++ b/Cogs/Configuration/Components/Tickets.py
@@ -864,7 +864,7 @@ async def TicketsEmbed(interaction: discord.Interaction, embed: discord.Embed):
     embed.description = (
         "> The Tickets Panel allows users to create and manage tickets for support, "
         "inquiries, or reports. You can customize ticket categories, forms, and permissions. "
-        "Learn more at [the documentation](https://docs.astrobirb.dev/)."
+        "Learn more at [the documentation](https://docs.astrobirb.dev/Modules/tickets)."
     )
     return embed
 

--- a/Cogs/Configuration/Components/stafflist.py
+++ b/Cogs/Configuration/Components/stafflist.py
@@ -6,6 +6,6 @@ async def StaffListEmbed(interaction: discord.Interaction, embed: discord.Embed)
     embed.description = (
         "> The Staff Panel displays a list of staff members, sorted by rank. "
         "You can view individual staff details, including their roles and join dates. "
-        "For more information, visit [the documentation](https://docs.astrobirb.dev/)."
+        "For more information, visit [the documentation](https://docs.astrobirb.dev/Modules/stafflist)."
     )
     return embed


### PR DESCRIPTION
Previously, all documentation links were linked to the main page (Introduction), instead of that, now every module has it's own documentation link