### PR TITLE
Update Documentation URL

### DIFF
--- a/utils/HelpEmbeds.py
+++ b/utils/HelpEmbeds.py
@@ -16,7 +16,7 @@ class Support(discord.ui.View):
         self.add_item(
             discord.ui.Button(
                 label="Documentation",
-                url="https://docs.astrobirb.dev/overview",
+                url="https://docs.astrobirb.dev",
                 style=discord.ButtonStyle.blurple,
                 emoji="📚",
             )


### PR DESCRIPTION
The current one leads to a 404 page when clicked.